### PR TITLE
Fixed bugs in generate_dataset.py

### DIFF
--- a/generate_dataset.py
+++ b/generate_dataset.py
@@ -131,6 +131,8 @@ class DataDownloader:
             print("[INFO] Downloading {} ".format(data.url))
             try :
                 # sometimes this fails because of known issues of pytube and unknown factors
+                # `pip uninstall pytube` and `pip install pytube` again would solve the problem 
+                # because the latest version has a patch to fix the issue
                 yt = YouTube(data.url)
                 stream = yt.streams.first()
                 stream.download('./','current_'+mode)
@@ -143,10 +145,13 @@ class DataDownloader:
 
             sleep(1)
 
+            videoname = ""
             videoname_candinate_list = glob.glob('./*')
             for videoname_candinate in videoname_candinate_list:
-                if videoname_candinate.split('.')[-2] == '/current_'+mode:
+                if videoname_candinate.split('.')[-1] == '/current_' + mode:
                     videoname = videoname_candinate
+            if videoname == "":
+                raise Exception("Video name doesn't exist")
 
             if len(data) == 1: # len(data) is len(data.list_seqnames)
                 process(data, 0, videoname, self.output_root)


### PR DESCRIPTION
Fixed bugs:

1. The latest version of pytube can work now. We just have to reinstall it. I added a comment to remind others of this approach.
2. `videoname` is referenced before the declaration. I declared this variable and checked None before using it to solve the error. 
3. At this line, we should use [-1], not [-2]: `if videoname_candinate.split('.')[-1] == '/current_' + mode:`. Because `./current_train` is the part we want to find. 